### PR TITLE
Circumvent Rackspace's 10,000 object return limit

### DIFF
--- a/src/RackspaceAdapter.php
+++ b/src/RackspaceAdapter.php
@@ -230,7 +230,7 @@ class RackspaceAdapter extends AbstractAdapter
             $partialResponse = iterator_to_array($partialResponse);
             $last = end($partialResponse);
             if ($last) {
-			    $marker = $last->getName();
+			$marker = $last->getName();
     		} else {
     			$marker = null;
     		}

--- a/src/RackspaceAdapter.php
+++ b/src/RackspaceAdapter.php
@@ -230,11 +230,11 @@ class RackspaceAdapter extends AbstractAdapter
             $partialResponse = iterator_to_array($partialResponse);
             $last = end($partialResponse);
             if ($last) {
-			$marker = $last->getName();
-    		} else {
-    			$marker = null;
-    		}
-    		$response = array_merge($response, $partialResponse);
+                $marker = $last->getName();
+            } else {
+                $marker = null;
+            }
+            $response = array_merge($response, $partialResponse);
         }
         $contents = array_map([$this, 'normalizeObject'], $response);
 

--- a/src/RackspaceAdapter.php
+++ b/src/RackspaceAdapter.php
@@ -223,8 +223,19 @@ class RackspaceAdapter extends AbstractAdapter
     public function listContents($directory = '', $recursive = false)
     {
         $location = $this->applyPathPrefix($directory);
-        $response = $this->container->objectList(['prefix' => $location]);
-        $response = iterator_to_array($response);
+        $marker = "";
+        $response = [];
+        while ($marker !== null) {
+            $partialResponse = $this->container->objectList(['prefix' => $location, 'marker' => $marker]);
+            $partialResponse = iterator_to_array($partialResponse);
+            $last = end($partialResponse);
+            if ($last) {
+			    $marker = $last->getName();
+    		} else {
+    			$marker = null;
+    		}
+    		$response = array_merge($response, $partialResponse);
+        }
         $contents = array_map([$this, 'normalizeObject'], $response);
 
         return Util::emulateDirectories($contents);


### PR DESCRIPTION
The Rackspace $container->objetList() call only returns 10,000 results max. In order to get around this, you need to make multiple calls, passing in the last object received as a marker. 
