### PR TITLE
Add container accessor

### DIFF
--- a/src/RackspaceAdapter.php
+++ b/src/RackspaceAdapter.php
@@ -41,6 +41,16 @@ class RackspaceAdapter extends AbstractAdapter
     }
 
     /**
+     * Get the container.
+     *
+     * @return Container
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
      * Get an object.
      *
      * @param string $path

--- a/tests/RackspaceAdapterTests.php
+++ b/tests/RackspaceAdapterTests.php
@@ -273,4 +273,11 @@ class RackspaceTests extends PHPUnit_Framework_TestCase
         $adapter = new Rackspace($container);
         $this->assertInternalType('array', $adapter->listContents('', true));
     }
+
+    public function testGetContainer() {
+      $container = $this->getContainerMock();
+      $adapter = new Rackspace($container);
+
+      $this->assertEquals($container, $adapter->getContainer());
+    }
 }


### PR DESCRIPTION
The AWS S3 adapter has a public [`getClient()`](https://github.com/thephpleague/flysystem-aws-s3-v2/blob/be6671c052d27f88565720f5f602255929f7ab96/src/AwsS3Adapter.php#L106-L114) method, allowing for access and use of the raw `S3Client` instance.

The Rackspace adapter doesn't have a similar accessor for the underlying OpenCloud container.

@frankdejonge [described](https://github.com/thephpleague/flysystem-rackspace/issues/2#issuecomment-102303286) adding a Rackspace-only plugin to fetch a CDN URL for an object. This can't be done without access to the container.

Also related to #2, #3, and #6, here's a plugin providing a `getUrl()` method on the adapter.

``` php
<?php

namespace League\Flysystem\Rackspace\Plugin;

use Guzzle\Http\Url;
use League\Flysystem\Plugin\AbstractPlugin;
use League\Flysystem\NotSupportedException;
use OpenCloud\ObjectStore\Constants\UrlType;

class GetUrl extends AbstractPlugin
{
    /**
     * Get the method name.
     *
     * @return string
     */
    public function getMethod()
    {
        return 'getUrl';
    }

    /**
     * Get the Url object for a path.
     *
     * @param string $path     path to file
     * @param string   $urlType  OpenCloud URL type
     *
     * @return Url
     */
    public function handle($path, $urlType = UrlType::SSL)
    {
        $container = $this->filesystem->getAdapter()->getContainer();

        if ( ! $container->isCdnEnabled()) {
          throw new NotSupportedException(
            'The Rackspace container must be CDN-enabled to fetch a public URL for ' . $path
          );
        }

        return $container->getObject($path)->getPublicUrl($urlType);
    }
}

```
