### PR TITLE
Use objectExists for has check.

### DIFF
--- a/src/RackspaceAdapter.php
+++ b/src/RackspaceAdapter.php
@@ -191,14 +191,13 @@ class RackspaceAdapter extends AbstractAdapter
     public function has($path)
     {
         try {
-            $object = $this->getObject($path);
+            $location = $this->applyPathPrefix($path);
+            $exists = $this->container->objectExists($location);
         } catch (ClientErrorResponseException $e) {
-            return false;
-        } catch (ObjectNotFoundException $e) {
             return false;
         }
 
-        return $this->normalizeObject($object);
+        return $exists;
     }
 
     /**

--- a/tests/RackspaceAdapterTests.php
+++ b/tests/RackspaceAdapterTests.php
@@ -64,15 +64,15 @@ class RackspaceTests extends PHPUnit_Framework_TestCase
         $container = $this->getContainerMock();
         $dataObject = $this->getDataObjectMock('filename.ext');
 
-        $container->shouldReceive('getObject')->andReturn($dataObject);
+        $container->shouldReceive('objectExists')->andReturn(true);
         $adapter = new Rackspace($container);
-        $this->assertInternalType('array', $adapter->has('filename.ext'));
+        $this->assertTrue($adapter->has('filename.ext'));
     }
 
     public function testHasFail()
     {
         $container = $this->getContainerMock();
-        $container->shouldReceive('getObject')->andThrow('Guzzle\Http\Exception\ClientErrorResponseException');
+        $container->shouldReceive('objectExists')->andThrow('Guzzle\Http\Exception\ClientErrorResponseException');
         $adapter = new Rackspace($container);
         $this->assertFalse($adapter->has('filename.ext'));
     }
@@ -80,7 +80,7 @@ class RackspaceTests extends PHPUnit_Framework_TestCase
     public function testHasNotFound()
     {
         $container = $this->getContainerMock();
-        $container->shouldReceive('getObject')->andThrow('OpenCloud\ObjectStore\Exception\ObjectNotFoundException');
+        $container->shouldReceive('objectExists')->andReturn(false);
         $adapter = new Rackspace($container);
         $this->assertFalse($adapter->has('filename.ext'));
     }


### PR DESCRIPTION
Means we simply get the head of the object to check it exists rather
than read the entire object which can take a long time if particularly
large file.

As we're only returning a boolean now this is a BC break, although if using through flysystem it shouldn't be an issue (https://github.com/thephpleague/flysystem/blob/master/src/Filesystem.php#L54). 

I don't actually use this library so not tested in real world situation or anything, just experienced issue with competing library and spotted the same issue here.
