### PR TITLE
Added the use of getPartialObject() for the metadata requests.

### DIFF
--- a/src/RackspaceAdapter.php
+++ b/src/RackspaceAdapter.php
@@ -65,6 +65,20 @@ class RackspaceAdapter extends AbstractAdapter
     }
 
     /**
+     * Get the metadata of an object.
+     *
+     * @param string $path
+     *
+     * @return DataObject
+     */
+    protected function getPartialObject($path)
+    {
+        $location = $this->applyPathPrefix($path);
+
+        return $this->container->getPartialObject($location);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function write($path, $contents, Config $config)
@@ -270,7 +284,7 @@ class RackspaceAdapter extends AbstractAdapter
      */
     public function getMetadata($path)
     {
-        $object = $this->getObject($path);
+        $object = $this->getPartialObject($path);
 
         return $this->normalizeObject($object);
     }

--- a/tests/RackspaceAdapterTests.php
+++ b/tests/RackspaceAdapterTests.php
@@ -178,7 +178,7 @@ class RackspaceTests extends PHPUnit_Framework_TestCase
     {
         $container = $this->getContainerMock();
         $dataObject = $this->getDataObjectMock('filename.ext');
-        $container->shouldReceive('getObject')->andReturn($dataObject);
+        $container->shouldReceive('getPartialObject')->andReturn($dataObject);
         $adapter = new Rackspace($container);
         $this->assertInternalType('array', $adapter->{$function}('filename.ext'));
     }


### PR DESCRIPTION
Using getObject() downloads the entire file whereas getPartialObject() only downloads the headers and not the content.
