### PR TITLE
Allow setting etag header when sending update requests

### DIFF
--- a/src/RackspaceAdapter.php
+++ b/src/RackspaceAdapter.php
@@ -103,6 +103,16 @@ class RackspaceAdapter extends AbstractAdapter
         $object = $this->getObject($path);
         $object->setContent($contents);
         $object->setEtag(null);
+
+        if ($config && $config->has('headers')) {
+            $headers =  $config->get('headers');
+            if (isset($headers['etag'])) {
+                $object->setEtag($headers['etag']);
+            } elseif (isset($headers['ETag'])) {
+                $object->setEtag($headers['ETag']);
+            }
+        }
+        
         $response = $object->update();
 
         if (! $response->getLastModified()) {

--- a/tests/RackspaceAdapterTests.php
+++ b/tests/RackspaceAdapterTests.php
@@ -279,4 +279,36 @@ class RackspaceTests extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($container, $adapter->getContainer());
     }
+
+    public function testUpdateWithUnrecognizedEtagHeader()
+    {
+        $container = $this->getContainerMock();
+        $dataObject = $this->getDataObjectMock('filename.ext');
+        $dataObject->shouldReceive('setContent');
+        $dataObject->shouldReceive('setEtag')->times(1);
+        $dataObject->shouldReceive('update')->andReturn(Mockery::self());
+        $container->shouldReceive('getObject')->andReturn($dataObject);
+        $adapter = new Rackspace($container);
+        $this->assertInternalType('array', $adapter->update('filename.ext', 'content', new Config([
+            'headers' => [
+                'etagg' => 'FOOBAR',
+            ],
+        ])));
+    }
+
+    public function testUpdateWithEtagHeader()
+    {
+        $container = $this->getContainerMock();
+        $dataObject = $this->getDataObjectMock('filename.ext');
+        $dataObject->shouldReceive('setContent');
+        $dataObject->shouldReceive('setEtag')->times(2);
+        $dataObject->shouldReceive('update')->andReturn(Mockery::self());
+        $container->shouldReceive('getObject')->andReturn($dataObject);
+        $adapter = new Rackspace($container);
+        $this->assertInternalType('array', $adapter->update('filename.ext', 'content', new Config([
+            'headers' => [
+                'etag' => 'FOOBAR',
+            ],
+        ])));
+    }
 }


### PR DESCRIPTION
I noticed that writes allowed etags to be passed for data integrity checks, but not update/put methods. This should fix that.